### PR TITLE
feat(auth): refactor auth flow with refresh interceptor and rootReducer reset

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,8 +17,16 @@ import {
 } from './routes/lazyPages';
 import RestrictedRoute from './routes/RestrictedRoute';
 import PrivateRoute from './routes/PrivateRoute';
+import { useDispatch } from 'react-redux';
+import { useEffect } from 'react';
+import { refreshUser } from './redux/auth/operations';
 
 function App() {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(refreshUser());
+  }, [dispatch]);
+
   return (
     <Routes>
       <Route path="/" element={<SharedLayout />}>

--- a/src/components/Layouts/SharedLayout.jsx
+++ b/src/components/Layouts/SharedLayout.jsx
@@ -1,16 +1,8 @@
 import Footer from '../common/Footer/Footer';
 import Header from '../common/Header/Header';
 import { Outlet } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
-import { useEffect } from 'react';
-import { refreshUser } from '../../redux/auth/operations';
 
 const SharedLayout = () => {
-  const dispatch = useDispatch();
-  useEffect(() => {
-    dispatch(refreshUser());
-  }, [dispatch]);
-
   return (
     <>
       <Header />

--- a/src/constants/auth.js
+++ b/src/constants/auth.js
@@ -1,2 +1,9 @@
 export const EMAIL_REGEX =
   /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+
+export const AUTH_ENDPOINTS = {
+  LOGIN: '/auth/login',
+  REGISTER: '/auth/register',
+  LOGOUT: '/auth/logout',
+  REFRESH: '/auth/refresh',
+};

--- a/src/redux/auth/operations.js
+++ b/src/redux/auth/operations.js
@@ -2,16 +2,16 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import { api } from '../../services/api';
 import {
   clearAccessToken,
-  getAccessToken,
   setAccessToken,
 } from '../../services/api/tokenStore';
+import { AUTH_ENDPOINTS } from '../../constants/auth';
 
 // REGISTER
 export const registerUser = createAsyncThunk(
   'auth/register',
   async (credentials, { dispatch, rejectWithValue }) => {
     try {
-      await api.post('/auth/register', credentials);
+      await api.post(AUTH_ENDPOINTS.REGISTER, credentials);
       const { name: _, ...loginCredentials } = credentials;
       await dispatch(loginUser(loginCredentials));
     } catch (error) {
@@ -27,9 +27,9 @@ export const loginUser = createAsyncThunk(
   'auth/login',
   async (credentials, { rejectWithValue }) => {
     try {
-      const { data } = await api.post('/auth/login', credentials);
+      const { data } = await api.post(AUTH_ENDPOINTS.LOGIN, credentials);
+
       setAccessToken(data.data.accessToken);
-      console.info('Login: ', getAccessToken());
     } catch (error) {
       return rejectWithValue(error.response?.data?.message || 'Login failed');
     }
@@ -41,7 +41,7 @@ export const refreshUser = createAsyncThunk(
   'auth/refresh',
   async (_, { rejectWithValue }) => {
     try {
-      const { data } = await api.post('/auth/refresh');
+      const { data } = await api.post(AUTH_ENDPOINTS.REFRESH);
       setAccessToken(data.data.accessToken);
     } catch (error) {
       return rejectWithValue(error.response?.data?.message || 'Refresh failed');
@@ -54,9 +54,8 @@ export const logoutUser = createAsyncThunk(
   'auth/logout',
   async (_, { rejectWithValue }) => {
     try {
-      await api.post('/auth/logout');
+      await api.post(AUTH_ENDPOINTS.LOGOUT);
       clearAccessToken();
-      console.info('Logout: ', getAccessToken());
     } catch (error) {
       return rejectWithValue(error.response?.data?.message || 'Refresh failed');
     }

--- a/src/redux/listenerMiddleware.js
+++ b/src/redux/listenerMiddleware.js
@@ -1,15 +1,12 @@
 import { createListenerMiddleware } from '@reduxjs/toolkit';
-import { loginUser, logoutUser, refreshUser } from './auth/operations';
+import { loginUser, refreshUser } from './auth/operations';
 import { fetchCurrentUser } from './user/operations';
-import { logout } from './auth/slice';
 
 const listenerMiddleware = createListenerMiddleware();
 const startAppListening = listenerMiddleware.startListening;
 
-const handleLogout = async (_, listenerApi) => {
-  await listenerApi.dispatch(logout());
-};
-
+// після логіну підтягнути профіль
+// after login fetch profile
 startAppListening({
   actionCreator: loginUser.fulfilled,
   effect: async (_, listenerApi) => {
@@ -20,13 +17,8 @@ startAppListening({
 startAppListening({
   actionCreator: refreshUser.fulfilled,
   effect: async (_, listenerApi) => {
-    await listenerApi.dispatch(fetchCurrentUser()); // подтянуть профиль
+    await listenerApi.dispatch(fetchCurrentUser());
   },
-});
-
-startAppListening({
-  actionCreator: logoutUser.fulfilled,
-  effect: handleLogout,
 });
 
 export default listenerMiddleware;

--- a/src/redux/rootReducer.js
+++ b/src/redux/rootReducer.js
@@ -1,0 +1,34 @@
+import { combineReducers } from '@reduxjs/toolkit';
+import authReducer from './auth/slice';
+import userReducer from './user/slice';
+import storiesReducer from './stories/slice';
+import travelersReducer from './travelers/slice';
+import storiesPopularReducer from './popularStories/slice';
+import ourTravellersReducer from './ourTravellers/slice';
+import { logoutUser } from './auth/operations';
+
+const appReducer = combineReducers({
+  auth: authReducer,
+  user: userReducer,
+  stories: storiesReducer,
+  travelers: travelersReducer,
+  popularStories: storiesPopularReducer, // редьюсер для популярних історій
+  ourTravellers: ourTravellersReducer,
+});
+
+const rootReducer = (state, action) => {
+  if (action.type === logoutUser.fulfilled.type) {
+    return appReducer(
+      {
+        ...state,
+        //reset private slices to initialState
+        auth: undefined,
+        user: undefined,
+      },
+      action
+    );
+  }
+  return appReducer(state, action);
+};
+
+export default rootReducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,23 +1,12 @@
-import { combineReducers, configureStore } from '@reduxjs/toolkit';
-import authReducer from './auth/slice';
-import userReducer from './user/slice';
-import storiesReducer from './stories/slice';
-import travelersReducer from './travelers/slice';
-import storiesPopularReducer from './popularStories/slice';
-import ourTravellersReducer from './ourTravellers/slice';
+import { configureStore } from '@reduxjs/toolkit';
 import listenerMiddleware from './listenerMiddleware';
-
-const rootReducer = combineReducers({
-  auth: authReducer,
-  user: userReducer,
-  stories: storiesReducer,
-  travelers: travelersReducer,
-  popularStories: storiesPopularReducer, // редьюсер для популярних історій
-  ourTravellers: ourTravellersReducer,
-});
+import rootReducer from './rootReducer';
+import { setupRefreshInterceptor } from '../services/api/refreshInterceptor';
+import { api } from '../services/api';
 
 export const store = configureStore({
   reducer: rootReducer,
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().prepend(listenerMiddleware.middleware),
 });
+setupRefreshInterceptor(api, store.dispatch);

--- a/src/services/api/refreshInterceptor.js
+++ b/src/services/api/refreshInterceptor.js
@@ -1,0 +1,55 @@
+import { setAccessToken } from './tokenStore';
+
+import { AUTH_ENDPOINTS } from '../../constants/auth';
+import { logoutUser } from '../../redux/auth/operations';
+
+export function setupRefreshInterceptor(api, dispatch) {
+  api.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+      const originalRequest = error.config;
+
+      if (!originalRequest) {
+        return Promise.reject(error);
+      }
+
+      // refresh повернув 401 - logout
+      // refresh request returne 401 - perform logout
+      if (
+        error.response?.status === 401 &&
+        (originalRequest.url.includes(AUTH_ENDPOINTS.REFRESH) ||
+          originalRequest.url.includes(AUTH_ENDPOINTS.LOGIN) ||
+          originalRequest.url.includes(AUTH_ENDPOINTS.REGISTER))
+      ) {
+        return Promise.reject(error);
+      }
+
+      // перший 401 для запиту - пробуємо оновити токен
+      // first 401 for request - try refreshing token
+      if (error.response?.status === 401 && !originalRequest._retry) {
+        originalRequest._retry = true;
+
+        try {
+          const { data } = await api.post(AUTH_ENDPOINTS.REFRESH);
+          const newToken = data.data.accessToken;
+          setAccessToken(newToken);
+
+          // додаємо новий токен у хедери та повторюємо оригінальний запит
+          // add new token to headers and retry the original request
+          originalRequest.headers = {
+            ...originalRequest.headers,
+            Authorization: `Bearer ${newToken}`,
+          };
+
+          return api(originalRequest);
+        } catch (refreshError) {
+          //  refresh  не вдався - logout
+          // refresh failed - logout
+          dispatch(logoutUser());
+          return Promise.reject(refreshError);
+        }
+      }
+      return Promise.reject(error);
+    }
+  );
+}


### PR DESCRIPTION
- creat constants for auth endpoints and replaced hardcoded paths in requests
- add RefreshInterceptor to handle 401 responses (auto refresh token or logout)
- move initial refresh from SharedLayout to App (run once on page reload)
- move logout logic from ListenerMiddleware to interceptor
- reset private slices (auth, user) on logout via rootReducer