### PR TITLE
feat(auth): add session initialization flag and improve refresh flow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,18 +17,26 @@ import {
 } from './routes/lazyPages';
 import RestrictedRoute from './routes/RestrictedRoute';
 import PrivateRoute from './routes/PrivateRoute';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useEffect } from 'react';
 import { refreshUser } from './redux/auth/operations';
 import SavedStories from './pages/ProfilePage/SavedStories';
 import CreatedStories from './pages/ProfilePage/CreatedStories';
 
+import { selectAuthState } from './redux/auth/selectors';
+import Loader from './components/common/Loader/Loader';
+
 function App() {
   const dispatch = useDispatch();
-  useEffect(() => {
-    dispatch(refreshUser());
-  }, [dispatch]);
+  const { isRefreshing, isInitialized } = useSelector(selectAuthState);
 
+  useEffect(() => {
+    if (!isInitialized && !isRefreshing) {
+      dispatch(refreshUser());
+    }
+  }, [dispatch, isInitialized, isRefreshing]);
+
+  if (!isInitialized && isRefreshing) return <Loader />;
   return (
     <Routes>
       <Route path="/" element={<SharedLayout />}>

--- a/src/redux/auth/selectors.js
+++ b/src/redux/auth/selectors.js
@@ -1,2 +1,3 @@
 export const selectIsLoggedIn = (state) => state.auth.isLoggedIn;
 export const selectAuthIsLoading = (state) => state.auth.isLoading;
+export const selectAuthState = (state) => state.auth;

--- a/src/redux/auth/slice.js
+++ b/src/redux/auth/slice.js
@@ -3,8 +3,9 @@ import { loginUser, registerUser, refreshUser } from './operations';
 import { fetchCurrentUser } from '../user/operations';
 
 const initialState = {
-  user: null,
   isLoading: false,
+  isInitialized: false,
+  isRefreshing: false,
   isLoggedIn: false,
   error: null,
 };
@@ -50,16 +51,18 @@ const authSlice = createSlice({
 
       // --- Refresh ---
       .addCase(refreshUser.pending, (state) => {
-        state.isLoading = true;
+        state.isRefreshing = true;
         state.error = null;
       })
       .addCase(refreshUser.fulfilled, (state) => {
-        state.isLoading = false;
+        state.isRefreshing = false;
+        state.isInitialized = true;
         state.isLoggedIn = true;
         state.error = null;
       })
       .addCase(refreshUser.rejected, (state, action) => {
-        state.isLoading = false;
+        state.isRefreshing = false;
+        state.isInitialized = true;
         state.error = action.payload;
       })
 

--- a/src/routes/PrivateRoute.jsx
+++ b/src/routes/PrivateRoute.jsx
@@ -1,10 +1,13 @@
 import { useSelector } from 'react-redux';
 import { Navigate } from 'react-router-dom';
-import { selectIsLoggedIn } from '../redux/auth/selectors';
+import { selectAuthState } from '../redux/auth/selectors';
+import Loader from '../components/common/Loader/Loader';
 
 const PrivateRoute = ({ children }) => {
-  const isLoggedIn = useSelector(selectIsLoggedIn);
-  return isLoggedIn ? children : <Navigate to={'/auth/register'} replace />;
+  const { isLoggedIn, isInitialized } = useSelector(selectAuthState);
+  if (!isInitialized) return <Loader />;
+
+  return isLoggedIn ? children : <Navigate to={'/auth/login'} replace />;
 };
 
 export default PrivateRoute;

--- a/src/routes/RestrictedRoute.jsx
+++ b/src/routes/RestrictedRoute.jsx
@@ -1,9 +1,10 @@
 import { useSelector } from 'react-redux';
 import { Navigate } from 'react-router-dom';
-import { selectIsLoggedIn } from '../redux/auth/selectors';
+import { selectAuthState } from '../redux/auth/selectors';
 
 const RestrictedRoute = ({ children }) => {
-  const isLoggedIn = useSelector(selectIsLoggedIn);
+  const { isLoggedIn, isInitialized } = useSelector(selectAuthState);
+  if (!isInitialized) return <Loader />;
   return isLoggedIn ? <Navigate to={'/'} replace /> : children;
 };
 


### PR DESCRIPTION
- added isInitialized and isRefreshing flags to auth slice
- updated reducers to set isInitialized=true after refresh fulfilled/rejected
- in App: dispatch refreshUser only once if not initialized
- show Loader while session is being checked (isRefreshing && !isInitialized)
- updated PrivateRoute and RestrictedRoute to block rendering until isInitialized