### PR TITLE
fix(populars, travellers): optimize useEffect calls on mount closes #112

### DIFF
--- a/src/components/OurTravellers/OurTravellers.jsx
+++ b/src/components/OurTravellers/OurTravellers.jsx
@@ -26,8 +26,9 @@ const OurTravellers = () => {
   );
 
   useEffect(() => {
-    dispatch(fetchOurTravellers({ page, perPage }));
-  }, [dispatch, page, perPage]);
+    if (!items.length && page === 1)
+      dispatch(fetchOurTravellers({ page, perPage }));
+  }, [dispatch, items.length, page, perPage]);
 
   const handleLoadMore = () => {
     dispatch(setPage(page + 1));
@@ -52,7 +53,7 @@ const OurTravellers = () => {
               type="button"
               size={isMobile ? 'sm' : 'md'}
               aria-label="Показати більше мандрівників"
-              disabled={isLoading} // добавь
+              disabled={isLoading}
             >
               {isLoading ? 'Завантаження...' : 'Переглянути всіх'}
             </AppButton>

--- a/src/components/common/Popular/Popular.jsx
+++ b/src/components/common/Popular/Popular.jsx
@@ -35,8 +35,8 @@ const Popular = () => {
 
   // завантажуєм історії
   useEffect(() => {
-    dispatch(fetchPopularStories());
-  }, [dispatch]);
+    if (!stories.length) dispatch(fetchPopularStories());
+  }, [dispatch, stories.length]);
 
   const handleLoadMore = () => {
     setVisibleCount((prevCount) => prevCount + limit);

--- a/src/pages/TravellersPage/TravellersPage.jsx
+++ b/src/pages/TravellersPage/TravellersPage.jsx
@@ -33,8 +33,9 @@ const TravellersPage = () => {
   const perPage = isDesktop ? 12 : 8;
 
   useEffect(() => {
-    dispatch(fetchTravellers({ page: currentPage, perPage }));
-  }, [dispatch, currentPage, perPage]);
+    if (!travelers.length && page === 1)
+      dispatch(fetchTravellers({ page: currentPage, perPage }));
+  }, [dispatch, travelers.length, currentPage, perPage, page]);
 
   const handleLoadMore = () => {
     if (page < totalPages) {


### PR DESCRIPTION
- added check for items array length before dispatching fetch
- prevented redundant API requests when navigating between pages
- applied optimization in Populars component and Travellers page