### PR TITLE
Add logout confirmation modal and improve modal/toast handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.12.2",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "focus-trap-react": "^11.0.4",
         "formik": "^2.4.6",
         "modern-normalize": "^3.0.1",
         "react": "^19.1.1",
@@ -1830,7 +1831,6 @@
       "version": "19.1.9",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -3165,6 +3165,31 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/focus-trap": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.5.tgz",
+      "integrity": "sha512-7Ke1jyybbbPZyZXFxEftUtxFGLMpE2n6A+z//m4CRDlj0hW+o3iYSmh8nFlYMurOiJVDmJRilUQtJr08KfIxlg==",
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.2.0"
+      }
+    },
+    "node_modules/focus-trap-react": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-11.0.4.tgz",
+      "integrity": "sha512-tC7jC/yqeAqhe4irNIzdyDf9XCtGSeECHiBSYJBO/vIN0asizbKZCt8TarB6/XqIceu42ajQ/U4lQJ9pZlWjrg==",
+      "license": "MIT",
+      "dependencies": {
+        "focus-trap": "^7.6.5",
+        "tabbable": "^6.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -5356,6 +5381,12 @@
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
       "license": "MIT"
     },
     "node_modules/tiny-case": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "axios": "^1.12.2",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "focus-trap-react": "^11.0.4",
     "formik": "^2.4.6",
     "modern-normalize": "^3.0.1",
     "react": "^19.1.1",

--- a/src/components/common/AppToastContainer/AppToastContainer.jsx
+++ b/src/components/common/AppToastContainer/AppToastContainer.jsx
@@ -1,64 +1,50 @@
-import { ToastContainer, cssTransition, toast } from 'react-toastify';
+import { ToastContainer, cssTransition } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
+import './AppToastContainer.css';
 
-// стилі в індекс
-// приклад визову тоста сакцес і еррор
-// import AppToastContainer, {
-//   showSuccessToast,
-//   showErrorToast
-// } from ....
-// приклад використання
-// if (!data) {
-//   showErrorToast("Даних нема");
-// } else {
-//   showSuccessToast("Все добре");
-// }
-
-// анімація тосту
 const BounceUp = cssTransition({
   enter: 'toast-bounce-in',
   exit: 'toast-bounce-out',
   duration: [350, 250],
 });
 
-// свг
-const SuccessIcon = (
-  <svg
-    className="toast-icon toast-success-icon"
-    viewBox="0 0 20 20"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    aria-hidden="true"
-  >
-    <path d="M5 10l4 4L15 7" />
-  </svg>
-);
+// // свг
+// const SuccessIcon = (
+//   <svg
+//     className="toast-icon toast-success-icon"
+//     viewBox="0 0 20 20"
+//     fill="none"
+//     stroke="currentColor"
+//     strokeWidth="2"
+//     aria-hidden="true"
+//   >
+//     <path d="M5 10l4 4L15 7" />
+//   </svg>
+// );
 
-const ErrorIcon = (
-  <svg
-    className="toast-icon toast-error-icon"
-    viewBox="0 0 20 20"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    aria-hidden="true"
-  >
-    <line x1="5" y1="5" x2="15" y2="15" />
-    <line x1="15" y1="5" x2="5" y2="15" />
-  </svg>
-);
+// const ErrorIcon = (
+//   <svg
+//     className="toast-icon toast-error-icon"
+//     viewBox="0 0 20 20"
+//     fill="none"
+//     stroke="currentColor"
+//     strokeWidth="2"
+//     aria-hidden="true"
+//   >
+//     <line x1="5" y1="5" x2="15" y2="15" />
+//     <line x1="15" y1="5" x2="5" y2="15" />
+//   </svg>
+// );
 
-// хелпери для визову
-export const showSuccessToast = (message) =>
-  toast.success(message, {
-    icon: SuccessIcon,
-    autoClose: 3000,
-    role: 'status',
-  });
+// // хелпери для визову
+// export const showSuccessToast = (message) =>
+//   toast.success(message, {
+//     icon: SuccessIcon,
+//     role: 'status',
+//   });
 
-export const showErrorToast = (message) =>
-  toast.error(message, { icon: ErrorIcon, autoClose: 3000, role: 'alert' });
+// export const showErrorToast = (message) =>
+//   toast.error(message, { icon: ErrorIcon, autoClose: 3000, role: 'alert' });
 
 // контейнер тосту
 function AppToastContainer() {
@@ -73,7 +59,6 @@ function AppToastContainer() {
       newestOnTop
       toastClassName="custom-toast"
       bodyClassName="custom-toast-body"
-      role="status"
       aria-live="polite"
       aria-atomic="true"
     />

--- a/src/components/common/AppToastContainer/toastHelpers.jsx
+++ b/src/components/common/AppToastContainer/toastHelpers.jsx
@@ -1,0 +1,61 @@
+import { toast } from 'react-toastify';
+
+// свг
+const SuccessIcon = (
+  <svg
+    className="toast-icon toast-success-icon"
+    viewBox="0 0 20 20"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    aria-hidden="true"
+  >
+    <path d="M5 10l4 4L15 7" />
+  </svg>
+);
+
+const ErrorIcon = (
+  <svg
+    className="toast-icon toast-error-icon"
+    viewBox="0 0 20 20"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    aria-hidden="true"
+  >
+    <line x1="5" y1="5" x2="15" y2="15" />
+    <line x1="15" y1="5" x2="5" y2="15" />
+  </svg>
+);
+
+/**
+ * Відображає тост із позитивним повідомленням (успішна дія).
+ *
+ * @function showSuccessToast
+ * @param {string} message - Текст повідомлення для користувача.
+ * @returns {React.ReactText} ID тосту, який може бути використаний для його подальшого керування.
+ *
+ * @example
+ * showSuccessToast('Ваш профіль успішно оновлено');
+ */
+export const showSuccessToast = (message) =>
+  toast.success(message, {
+    icon: SuccessIcon,
+    role: 'status', // ✔️ правильне значення
+  });
+
+/**
+ * Відображає тост із негативним повідомленням (помилка).
+ *
+ * @function showErrorToast
+ * @param {string} message - Текст повідомлення про помилку.
+ * @returns {React.ReactText} ID тосту, який може бути використаний для його подальшого керування.
+ *
+ * @example
+ * showErrorToast('Не вдалося зберегти дані. Спробуйте ще раз.');
+ */
+export const showErrorToast = (message) =>
+  toast.error(message, {
+    icon: ErrorIcon,
+    role: 'alert', // ✔️ для помилок
+  });

--- a/src/components/common/InfoModal/InfoModal.jsx
+++ b/src/components/common/InfoModal/InfoModal.jsx
@@ -1,11 +1,63 @@
 import { useEffect, useRef } from 'react';
 import css from './InfoModal.module.css';
 import clsx from 'clsx';
-import FocusTrap from 'focus-trap-react';
-import { ReactComponent as CloseIcon } from '../../../assets/icons/close.svg';
+
+import CloseIcon from '../../../assets/icons/close.svg?react';
 import AppButton from '../../ui/AppButton/AppButton.jsx';
+import { FocusTrap } from 'focus-trap-react';
+
+/**
+ * Компонент модального вікна з інформаційним повідомленням та кнопками підтвердження/скасування.
+ * Використовується для відображення діалогових повідомлень, які потребують дії користувача.
+ *
+ * Особливості:
+ * - Рендериться лише коли `isOpen === true`.
+ * - Закривається по кліку на бекдроп, натисканню клавіші `Escape`, кнопці скасування або іконці закриття.
+ * - Використовує `focus-trap-react` для утримання фокусу всередині модального вікна.
+ *
+ * @component
+ *
+ * @param {Object} props - Властивості компонента.
+ * @param {boolean} props.isOpen - Визначає, чи модалка відкрита.
+ * @param {string} [props.title] - Заголовок модального вікна.
+ * @param {string} [props.text] - Основний текст повідомлення.
+ * @param {string} [props.confirmButtonText='Вийти'] - Текст кнопки підтвердження.
+ * @param {string} [props.cancelButtonText='Відмінити'] - Текст кнопки скасування.
+ * @param {() => void} [props.onConfirm] - Колбек, що викликається при натисканні кнопки підтвердження.
+ * @param {() => void} [props.onCancel] - Колбек, що викликається при закритті модалки (бекдроп, Esc, кнопка скасування, іконка).
+ * @param {string} [props.className] - Додаткові CSS-класи для контейнера модалки.
+ * @param {Object} [props.props] - Будь-які інші пропси, що будуть прокинуті в контейнер.
+ *
+ * @example <caption>Просте використання</caption>
+ * const [isOpen, setIsOpen] = useState(false);
+ *
+ * <>
+ *   <button onClick={() => setIsOpen(true)}>Відкрити</button>
+ *   <InfoModal
+ *     isOpen={isOpen}
+ *     title="Ви точно хочете вийти?"
+ *     text="Ми будемо сумувати за вами!"
+ *     confirmButtonText="Вийти"
+ *     cancelButtonText="Відмінити"
+ *     onConfirm={() => setIsOpen(false)}
+ *     onCancel={() => setIsOpen(false)}
+ *   />
+ * </>
+ *
+ * @example <caption>З кастомним текстом кнопок</caption>
+ * <InfoModal
+ *   isOpen={true}
+ *   title="Видалити елемент?"
+ *   text="Цю дію не можна буде скасувати."
+ *   confirmButtonText="Так, видалити"
+ *   cancelButtonText="Скасувати"
+ *   onConfirm={handleDelete}
+ *   onCancel={closeModal}
+ * />
+ */
 
 const InfoModal = ({
+  isOpen,
   title,
   text,
   confirmButtonText = 'Вийти',
@@ -15,8 +67,10 @@ const InfoModal = ({
   className,
   ...props
 }) => {
+  const cancelBtnRef = useRef(null);
   // закрити по еск
   useEffect(() => {
+    if (!isOpen) return;
     const handleEsc = (e) => {
       if (e.key === 'Escape') {
         onCancel?.();
@@ -24,7 +78,7 @@ const InfoModal = ({
     };
     window.addEventListener('keydown', handleEsc);
     return () => window.removeEventListener('keydown', handleEsc);
-  }, [onCancel]);
+  }, [onCancel, isOpen]);
 
   // закрити по бекдропу
   const handleBackdropClick = (e) => {
@@ -33,15 +87,15 @@ const InfoModal = ({
     }
   };
 
-  const cancelBtnRef = useRef(null);
+  if (!isOpen) return null;
 
   return (
-    <div className={css.backdrop} onClick={handleBackdropClick}>
-      <FocusTrap
-        focusTrapOptions={{
-          initialFocus: cancelBtnRef,
-        }}
-      >
+    <FocusTrap
+      focusTrapOptions={{
+        initialFocus: () => cancelBtnRef.current,
+      }}
+    >
+      <div className={css.backdrop} onClick={handleBackdropClick}>
         <div
           className={clsx(css.modal, className)}
           {...props}
@@ -94,8 +148,8 @@ const InfoModal = ({
             )}
           </div>
         </div>
-      </FocusTrap>
-    </div>
+      </div>
+    </FocusTrap>
   );
 };
 export default InfoModal;

--- a/src/components/ui/UserBar/UserBar.jsx
+++ b/src/components/ui/UserBar/UserBar.jsx
@@ -7,15 +7,20 @@ import { useNavigate } from 'react-router-dom';
 import { logoutUser } from '../../../redux/auth/operations';
 import clsx from 'clsx';
 import InfoModal from '../../common/InfoModal/InfoModal';
+import { showErrorToast } from '../../common/AppToastContainer/toastHelpers';
 
 function UserBar({ isLoggedIn, user }) {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(false); // Confirm modal state
 
-  const handleLogout = () => {
-    dispatch(logoutUser());
-    navigate('/');
+  const handleLogout = async () => {
+    try {
+      await dispatch(logoutUser()).unwrap();
+      navigate('/');
+    } catch {
+      showErrorToast('Не вдалося вийти. Спробуйте ще раз.');
+    }
   };
 
   // JSX

--- a/src/components/ui/UserBar/UserBar.jsx
+++ b/src/components/ui/UserBar/UserBar.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import s from './UserBar.module.css';
 import { useDispatch } from 'react-redux';
 
@@ -6,10 +6,12 @@ import Logout from '../../../assets/icons/logout.svg?react';
 import { useNavigate } from 'react-router-dom';
 import { logoutUser } from '../../../redux/auth/operations';
 import clsx from 'clsx';
+import InfoModal from '../../common/InfoModal/InfoModal';
 
 function UserBar({ isLoggedIn, user }) {
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const [isOpen, setIsOpen] = useState(false); // Confirm modal state
 
   const handleLogout = () => {
     dispatch(logoutUser());
@@ -34,10 +36,17 @@ function UserBar({ isLoggedIn, user }) {
           <button
             className={s.logoutBtn}
             aria-label="Вихід"
-            onClick={handleLogout}
+            onClick={() => setIsOpen(true)}
           >
             <Logout />
           </button>
+          <InfoModal
+            isOpen={isOpen}
+            title="Ви точно хочете вийти?"
+            text="Ми будемо сумувати за вами!"
+            onCancel={() => setIsOpen(false)}
+            onConfirm={handleLogout}
+          />
         </>
       )}
     </div>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { store } from './redux/store.js';
 import App from './App.jsx';
+import AppToastContainer from './components/common/AppToastContainer/AppToastContainer.jsx';
 import './styles/index.css';
 
 createRoot(document.getElementById('root')).render(
@@ -12,6 +13,7 @@ createRoot(document.getElementById('root')).render(
       <BrowserRouter>
         <App />
       </BrowserRouter>
+      <AppToastContainer />
     </Provider>
   </StrictMode>
 );


### PR DESCRIPTION
- Added logout confirmation via InfoModal in UserBar
- Implemented isOpen prop in InfoModal and fixed backdrop/Escape close behavior
- Integrated focus-trap-react for focus management
- Connected global AppToastContainer and moved toast helpers with JSDoc documentation
- Fixed logout flicker by using unwrap to ensure navigation only after thunk fulfillment